### PR TITLE
Extend :watchdog option to accept an ExecuteWatchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ options
 * **:in** *(String or InputStream)* is fed to the sub-process's stdin.
 * **:flush-input?** *(boolean)* flush or not input stream.
 * **:handle-quoting?** *(boolean)* Add the argument with/without handling quoting.
-* **:watchdog** *(int)* set watchdog timer in ms.
+* **:watchdog** (*int* or instance of *ExecuteWatchdog*) set watchdog timer in ms.
 * **:env** *(Map)* The environment for the new process. If null, the environment of the current process is used.
 * **:add-env** *(Map)* The added environment for the new process.
 * **:shutdown** *(boolean)* destroys sub-processes when the VM exits.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.hozumi/clj-commons-exec "1.0.6"
+(defproject org.clojars.hozumi/clj-commons-exec "1.0.7"
   :description "Apache Commons Exec wrapper for Clojure"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.apache.commons/commons-exec "1.1"]]


### PR DESCRIPTION
This allows the running process to be killed by calling destroyProcess
on the watchdog.
