### PR TITLE
Fix promise returned by clj-commons-exec/sh is unrealized when output pipe closed by a third party.

### DIFF
--- a/src/clj_commons_exec.clj
+++ b/src/clj_commons_exec.clj
@@ -34,23 +34,27 @@
   ExecuteResultHandler
   (onProcessComplete
    [_ exit-value]
-   (when (and in (:close-in? opts)) (.close ^InputStream in))
-   (when (and out (:close-out? opts)) (.close ^OutputStream out))
-   (when (and err (:close-err? opts)) (.close ^OutputStream err))
-   (deliver result
-            {:exit exit-value
-             :out (convert-baos-into-x out (:encode opts))
-             :err (convert-baos-into-x err (:encode opts))}))
+   (try
+     (when (and in (:close-in? opts)) (.close ^InputStream in))
+     (when (and out (:close-out? opts)) (.close ^OutputStream out))
+     (when (and err (:close-err? opts)) (.close ^OutputStream err))
+     (finally 
+       (deliver result
+                {:exit exit-value
+                 :out (convert-baos-into-x out (:encode opts))
+                 :err (convert-baos-into-x err (:encode opts))}))))
   (onProcessFailed
    [_ e]
-   (when (and in (:close-in? opts)) (.close ^InputStream in))
-   (when (and out (:close-out? opts)) (.close ^OutputStream out))
-   (when (and err (:close-err? opts)) (.close ^OutputStream err))
-   (deliver result
-            {:exit (.getExitValue e)
-             :out (convert-baos-into-x out (:encode opts))
-             :err (convert-baos-into-x err (:encode opts))
-             :exception e})))
+   (try
+     (when (and in (:close-in? opts)) (.close ^InputStream in))
+     (when (and out (:close-out? opts)) (.close ^OutputStream out))
+     (when (and err (:close-err? opts)) (.close ^OutputStream err))
+     (finally
+       (deliver result
+                {:exit (.getExitValue e)
+                 :out (convert-baos-into-x out (:encode opts))
+                 :err (convert-baos-into-x err (:encode opts))
+                 :exception e})))))
 
 (defrecord FlushStreamPumper [^InputStream is ^OutputStream os]
   Runnable


### PR DESCRIPTION
I'm using `sh` with pipes. In some circumstances the output pipe can close before the process exits. When used along with `:close-out?`, it results in unrealized promise.

``` clojure
(let [promise (exec/sh [... "stdout"]
                         {:out        out-pipe
                          :close-out? true})]
;;  ... out-pipe gets closed by a third party
;; ... the process finishes
(assert (realized? promise)) ;; AssertError
```

Please let me know if you need more details.
